### PR TITLE
Fix content-type, allow all directives, force Contact:, allow multiple same directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ const app = express()
 
 app.get('/security.txt', securityTxt({
   // your security address
-  contact: 'mailto:email@example.com',
+  contact: [
+    'mailto:email@example.com',
+    'tel:+123456789'
+   ],
   // your pgp key
   encryption: 'encryption',
   // if you have a hall of fame for securty resourcers, include link here

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ const app = express()
 
 app.get('/security.txt', securityTxt({
   // your security address
-  contact: 'email@example.com',
+  contact: 'mailto:email@example.com',
   // your pgp key
   encryption: 'encryption',
   // if you have a hall of fame for securty resourcers, include link here
-  acknowledgements: 'http://acknowledgements.example.com'
+  acknowledgements: 'https://acknowledgements.example.com'
 }))
 ```

--- a/index.js
+++ b/index.js
@@ -12,9 +12,11 @@ module.exports = function (fields) {
     }
   }
   
+  const securityTxtString = securityTxt.join("\n")
+  
   return function (request, response) {
     response.header("Content-Type", "text/plain");
-    response.send(securityTxt.join("\n"))
+    response.send(securityTxtString)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,21 +1,22 @@
 module.exports = function (fields) {
-  if(!Object.keys(fields).map(normalizeCase).includes("Contact"))
-    throw "You must include a `contact` property for security.txt";
-  
+  if (!Object.keys(fields).map(normalizeCase).includes('Contact')) {
+    throw new Error('You must include a `contact` property for security.txt')
+  }
+
   const securityTxt = []
 
-  for(const directive in fields) {
+  for (const directive in fields) {
     const key = normalizeCase(directive)
-    
-    for(const value of forceToArray(fields[directive])) {
+
+    for (const value of forceToArray(fields[directive])) {
       securityTxt.push(`${key}: ${value}`)
     }
   }
-  
-  const securityTxtString = securityTxt.join("\n")
-  
+
+  const securityTxtString = securityTxt.join('\n')
+
   return function (request, response) {
-    response.header("Content-Type", "text/plain");
+    response.header('Content-Type', 'text/plain')
     response.send(securityTxtString)
   }
 }
@@ -27,8 +28,8 @@ module.exports = function (fields) {
  * @param {string} string - The string to convert
  * @return {string} The capitalized form of the string
  */
-function normalizeCase(string) {
-  return string[0].toUpperCase() + string.substr(1).toLowerCase();
+function normalizeCase (string) {
+  return string[0].toUpperCase() + string.substr(1).toLowerCase()
 }
 
 /**
@@ -39,8 +40,8 @@ function normalizeCase(string) {
  * @param {string|array} stringOrArray - The string or array to force to an array
  * @return {array} The array form of the argument
  */
-function forceToArray(stringOrArray) {
-  if(Array.isArray(stringOrArray)) {
+function forceToArray (stringOrArray) {
+  if (Array.isArray(stringOrArray)) {
     return stringOrArray
   } else {
     return [stringOrArray]

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function (fields) {
   for (const directive in fields) {
     const key = normalizeCase(directive)
 
-    for (const value of forceToArray(fields[directive])) {
+    for (const value of ensureArray(fields[directive])) {
       securityTxt.push(`${key}: ${value}`)
     }
   }
@@ -40,7 +40,7 @@ function normalizeCase (string) {
  * @param {string|array} stringOrArray - The string or array to force to an array
  * @return {array} The array form of the argument
  */
-function forceToArray (stringOrArray) {
+function ensureArray (stringOrArray) {
   if (Array.isArray(stringOrArray)) {
     return stringOrArray
   } else {

--- a/index.js
+++ b/index.js
@@ -1,10 +1,45 @@
-module.exports = function (options) {
+module.exports = function (fields) {
+  if(!Object.keys(fields).map(normalizeCase).includes("Contact"))
+    throw "You must include a `contact` property for security.txt";
+  
+  const securityTxt = []
+
+  for(const directive in fields) {
+    const key = normalizeCase(directive)
+    
+    for(const value of forceToArray(fields[directive]) {
+      securityTxt.push(`${key}: ${value}`)
+    }
+  }
+  
   return function (request, response) {
-    const securityTxt = Object.keys(options).map(option => {
-      
-    })
-    response.send(
-      `Contact: ${options.contact}\nEncryption: ${options.encryption}\nAcknowledgements: ${options.acknowledgements}`
-    )
+    response.send(securityTxt.join("\n"))
+  }
+}
+
+/**
+ * Internal function to convert a string to one where the first
+ * character is uppercase, and all subsequent are lowercase.
+ *
+ * @param {string} string - The string to convert
+ * @return {string} The capitalized form of the string
+ */
+function normalizeCase(string) {
+  return string[0].toUpperCase() + string.substr(1).toLowerCase();
+}
+
+/**
+ * Internal function. Returns arrays as passed, but converts some
+ * string X into an array [X] of length 1. For example, "abc" would
+ * become ["abc"].
+ *
+ * @param {string|array} stringOrArray - The string or array to force to an array
+ * @return {array} The array form of the argument
+ */
+function forceToArray(stringOrArray) {
+  if(Array.isArray(stringOrArray)) {
+    return stringOrArray
+  } else {
+    return [stringOrArray]
   }
 }

--- a/index.js
+++ b/index.js
@@ -7,12 +7,13 @@ module.exports = function (fields) {
   for(const directive in fields) {
     const key = normalizeCase(directive)
     
-    for(const value of forceToArray(fields[directive]) {
+    for(const value of forceToArray(fields[directive])) {
       securityTxt.push(`${key}: ${value}`)
     }
   }
   
   return function (request, response) {
+    response.header("Content-Type", "text/plain");
     response.send(securityTxt.join("\n"))
   }
 }

--- a/test.js
+++ b/test.js
@@ -33,7 +33,7 @@ test('Security.txt only requires Contact', function (t) {
     .get('/security.txt')
     .expect(200)
     .end(function (err, res) {
-      t.equal(res.text, `Contact: email@example.com\n`)
+      t.equal(res.text, `Contact: email@example.com`)
       t.end(err)
     })
 })


### PR DESCRIPTION
There were a few issues I observed which made the generated security.txt file not too useful, or not compliant with the specification.

- **The resulting file was of Content-Type `text/html`, not `text/plain`.** 
  - Harder to read
  - Not spec-compliant
- **Not all directives were allowed**.
  - Only three directives were allowed
  - This PR makes all (including invalid directives) legal
- **No error was generated for lack of a `Contact:`**.
  - This pull request will throw if you fail to provide a `Contact` property (regardless of capitalisation, per spec)
- **Directives were only allowed once.**
  - Multiple contact methods, etc. could not be communicated
  - You can now pass arrays
  - The passing of arrays is now documented in the README
- **The entire file was re-generated every time**.
  - The security.txt file is mostly calculated upon its definition now, and then it's just returned. This is more efficient if it's being requested many times; and allows it to error immediately if the security.txt file is invalid.